### PR TITLE
feature/no-weapon-drop-on-Q

### DIFF
--- a/src/main/java/org/dredd/bulletcore/BulletCore.java
+++ b/src/main/java/org/dredd/bulletcore/BulletCore.java
@@ -11,6 +11,8 @@ import org.dredd.bulletcore.config.YMLLModelLoader;
 import org.dredd.bulletcore.config.messages.MessageManager;
 import org.dredd.bulletcore.custom_item_manager.registries.CustomItemsRegistry;
 import org.dredd.bulletcore.listeners.BulletCoreListener;
+import org.dredd.bulletcore.listeners.PlayerActionsListener;
+import org.dredd.bulletcore.listeners.trackers.PlayerActionTracker;
 
 import static org.dredd.bulletcore.commands.CommandHandler.MAIN_COMMAND_NAME;
 
@@ -64,7 +66,10 @@ public final class BulletCore extends JavaPlugin {
         ConfigManager.reload(this);
         YMLLModelLoader.loadAllItems(this);
         registerCommand(MAIN_COMMAND_NAME, new CommandHandler());
-        registerListener(new BulletCoreListener());
+
+        PlayerActionTracker tracker = new PlayerActionTracker();
+        registerListener(new BulletCoreListener(tracker));
+        registerListener(new PlayerActionsListener(tracker));
 
         plugin.getLogger().info("Version: " + version + " - Plugin Enabled");
         plugin.getLogger().info("==================================================================");

--- a/src/main/java/org/dredd/bulletcore/listeners/PlayerActionsListener.java
+++ b/src/main/java/org/dredd/bulletcore/listeners/PlayerActionsListener.java
@@ -1,0 +1,62 @@
+package org.dredd.bulletcore.listeners;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.dredd.bulletcore.listeners.trackers.PlayerActionTracker;
+
+/**
+ * Listens for player actions and records them using {@link PlayerActionTracker}.
+ *
+ * @author dredd
+ * @since 1.0.0
+ */
+public class PlayerActionsListener implements Listener {
+
+    private final PlayerActionTracker tracker;
+
+    /**
+     * Constructs a new listener using the provided tracker instance.
+     *
+     * @param tracker the {@link PlayerActionTracker} used to store inventory interaction timestamps
+     */
+    public PlayerActionsListener(PlayerActionTracker tracker) {
+        this.tracker = tracker;
+    }
+
+    /**
+     * Called when a player clicks in an inventory.<br>
+     * Updates the player's last inventory interaction time.
+     *
+     * @param event the {@link InventoryClickEvent} triggered
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onInventoryInteract(InventoryClickEvent event) {
+        tracker.markInventoryInteraction(event.getWhoClicked().getUniqueId());
+    }
+
+    /**
+     * Called when a player drags items in an inventory.<br>
+     * Updates the player's last inventory interaction time.
+     *
+     * @param event the {@link InventoryDragEvent} triggered
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onInventoryDrag(InventoryDragEvent event) {
+        tracker.markInventoryInteraction(event.getWhoClicked().getUniqueId());
+    }
+
+    /**
+     * Called when a player quits the server.<br>
+     * Clears tracking information for the player.
+     *
+     * @param event the {@link PlayerQuitEvent} triggered
+     */
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        tracker.clear(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/org/dredd/bulletcore/listeners/trackers/PlayerActionTracker.java
+++ b/src/main/java/org/dredd/bulletcore/listeners/trackers/PlayerActionTracker.java
@@ -1,0 +1,48 @@
+package org.dredd.bulletcore.listeners.trackers;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Tracks the most recent interactions (e.g., inventory clicks) for each player.
+ *
+ * @author dredd
+ * @since 1.0.0
+ */
+public class PlayerActionTracker {
+
+    /**
+     * Stores last inventory interaction time for each player.
+     */
+    private final Map<UUID, Long> lastInventoryInteraction = new HashMap<>();
+
+    /**
+     * Marks the current time as the player's last inventory interaction.
+     *
+     * @param uuid the unique ID of the player
+     */
+    public void markInventoryInteraction(UUID uuid) {
+        lastInventoryInteraction.put(uuid, System.currentTimeMillis());
+    }
+
+    /**
+     * Returns the timestamp (in milliseconds) of the player's last inventory interaction.
+     * If no interaction has been recorded, returns {@code 0}.
+     *
+     * @param uuid the unique ID of the player
+     * @return the last interaction time in milliseconds, or {@code 0} if none recorded
+     */
+    public long getLastInventoryInteraction(UUID uuid) {
+        return lastInventoryInteraction.getOrDefault(uuid, 0L);
+    }
+
+    /**
+     * Clears the recorded inventory interaction time for the given player.
+     *
+     * @param uuid the unique ID of the player
+     */
+    public void clear(UUID uuid) {
+        lastInventoryInteraction.remove(uuid);
+    }
+}

--- a/src/main/java/org/dredd/bulletcore/models/weapons/Weapon.java
+++ b/src/main/java/org/dredd/bulletcore/models/weapons/Weapon.java
@@ -17,6 +17,17 @@ public class Weapon extends CustomBase {
         super(attrs);
     }
 
+    /**
+     * Triggered when a player attempts to drop a weapon.
+     * This method is invoked specifically when the drop action is initiated manually with the drop key (Q).
+     *
+     * @param player   the player who attempts to drop the weapon
+     * @param usedItem the item being dropped, which is this weapon object
+     */
+    public void onDrop(@NotNull Player player, @NotNull ItemStack usedItem) {
+        //System.out.println("Weapon drop attempt on key (Q)");
+    }
+
     @Override
     public @NotNull ItemStack createItemStack() {
         // Add only weapon-specific attributes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Prevents custom weapons from being dropped using the drop key (Q), while still allowing drops through inventory GUI interactions.
  - Introduced improved tracking of player inventory interactions for more precise event handling.

- **Bug Fixes**
  - Ensures weapon drops caused by GUI actions are not mistakenly blocked.

- **Other Changes**
  - Added groundwork for custom behavior when a weapon is manually dropped, enabling future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->