### PR TITLE
feature-pellets_per_shot

### DIFF
--- a/src/main/java/org/dredd/bulletcore/config/YMLLModelLoader.java
+++ b/src/main/java/org/dredd/bulletcore/config/YMLLModelLoader.java
@@ -288,6 +288,7 @@ public final class YMLLModelLoader {
         long reloadTime = Math.clamp(config.getLong("reloadTime", 3000L), 100L, Long.MAX_VALUE);
         boolean isAutomatic = config.getBoolean("isAutomatic", false);
         double victimKnockbackResistance = Math.clamp(config.getDouble("victimKnockbackResistance", 0.0D), 0.0D, 1.0D);
+        int pelletsPerShot = Math.clamp(config.getInt("pelletsPerShot", 1), 1, 20);
 
         WeaponDamage damage = WeaponDamage.load(config);
         WeaponRecoil recoil = WeaponRecoil.load(config);
@@ -302,6 +303,6 @@ public final class YMLLModelLoader {
         lore.add(2, LORE_WEAPON_DISTANCE.of(maxDistance));
         lore.add(3, LORE_WEAPON_AMMO.of(ammo.displayNameString));
 
-        return new Weapon(baseAttributes, ammo, reloadHandler, maxDistance, delayBetweenShots, maxBullets, reloadTime, isAutomatic, victimKnockbackResistance, damage, recoil, spray, sounds, trailParticle, skins);
+        return new Weapon(baseAttributes, ammo, reloadHandler, maxDistance, delayBetweenShots, maxBullets, reloadTime, isAutomatic, victimKnockbackResistance, pelletsPerShot, damage, recoil, spray, sounds, trailParticle, skins);
     }
 }

--- a/src/main/java/org/dredd/bulletcore/models/weapons/Weapon.java
+++ b/src/main/java/org/dredd/bulletcore/models/weapons/Weapon.java
@@ -89,6 +89,11 @@ public class Weapon extends CustomBase {
     public final double victimKnockbackResistance;
 
     /**
+     * Number of projectiles fired per one ammo unit.
+     */
+    public final int pelletsPerShot;
+
+    /**
      * Weapon damage values for each body part.
      */
     public final WeaponDamage damage;
@@ -123,7 +128,7 @@ public class Weapon extends CustomBase {
      * <p>
      * All parameters must be already validated.
      */
-    public Weapon(BaseAttributes attrs, Ammo ammo, ReloadHandler reloadHandler, double maxDistance, long delayBetweenShots, int maxBullets, long reloadTime, boolean isAutomatic, double victimKnockbackResistance, WeaponDamage damage, WeaponRecoil recoil, WeaponSpray spray, WeaponSounds sounds, BulletTrailParticle trailParticle, WeaponSkins skins) {
+    public Weapon(BaseAttributes attrs, Ammo ammo, ReloadHandler reloadHandler, double maxDistance, long delayBetweenShots, int maxBullets, long reloadTime, boolean isAutomatic, double victimKnockbackResistance, int pelletsPerShot, WeaponDamage damage, WeaponRecoil recoil, WeaponSpray spray, WeaponSounds sounds, BulletTrailParticle trailParticle, WeaponSkins skins) {
         super(attrs);
         this.ammo = ammo;
         this.reloadHandler = reloadHandler;
@@ -134,6 +139,7 @@ public class Weapon extends CustomBase {
         this.reloadTime = reloadTime;
         this.isAutomatic = isAutomatic;
         this.victimKnockbackResistance = victimKnockbackResistance;
+        this.pelletsPerShot = pelletsPerShot;
         this.damage = damage;
         this.recoil = recoil;
         this.spray = spray;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a pellets-per-shot setting in weapon configs (default 1, range 1–20) to enable multi-projectile shots.
  - Each pellet now has independent trajectory, hit detection, damage, particles, sounds, and impact effects, enabling shotgun-like behavior.
  - Existing weapons remain unchanged unless pellets-per-shot is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->